### PR TITLE
Potential fix for code scanning alert no. 12: Database query built from user-controlled sources

### DIFF
--- a/helpers/userSessionsHandler.js
+++ b/helpers/userSessionsHandler.js
@@ -21,7 +21,7 @@ async function readUserSessions() {
 
 async function getUserSession(username) {
   try {
-    const session = await userSessionHandler.findOne({ username });
+    const session = await userSessionHandler.findOne({ username: { $eq: username } });
     return session;
   } catch (error) {
     console.error("Error getting user session from MongoDB:", error.message);
@@ -32,7 +32,7 @@ async function getUserSession(username) {
 async function saveUserSession(username, sessionData) {
   try {
     await userSessionHandler.updateOne(
-      { username },
+      { username: { $eq: username } },
       {
         $set: {
           lastKnownGrades: sessionData.lastKnownGrades,
@@ -53,7 +53,7 @@ async function writeUserSessions(sessions) {
   try {
     const bulkOps = Object.entries(sessions).map(([username, session]) => ({
       updateOne: {
-        filter: { username },
+        filter: { username: { $eq: username } },
         update: {
           $set: {
             lastKnownGrades: session.lastKnownGrades,


### PR DESCRIPTION
Potential fix for [https://github.com/MohamedWElteir/grades-checker/security/code-scanning/12](https://github.com/MohamedWElteir/grades-checker/security/code-scanning/12)

To fix this issue, we need to ensure that the `username` parameter is interpreted strictly as a literal value in MongoDB queries. We can achieve this by using the `$eq` operator in the query object, which forces MongoDB to treat the value as a literal string. Alternatively, we could validate `username` to ensure it is a string and conforms to expected formats before embedding it into the query object.

The single best way to resolve the issue is to modify the query in `saveUserSession()` to use `$eq`, ensuring that `username` is safely interpreted as a literal value. The same fix should be applied to other MongoDB queries in `helpers/userSessionsHandler.js` that use `username`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
